### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ const sigParams = SignatureParamsG1.generate(5, label);
 
 // Signers keys
 const sigSk: BBSPlusSecretKey = ...;
-const sigPk: BBSPlusSecretKey = ...;
+const sigPk: BBSPlusPublicKeyG2 = ...;
 
 // Accumulator manager's params, keys and state
 const accumParams = PositiveAccumulator.generateParams(stringToBytes('Accumulator params'));


### PR DESCRIPTION
Actually not sure if this is correct - but the only other occurence of `sigPk` is a `BBSPlusPublicKeyG2`. At least it looks wrong to have the `sigPk` be of type `BBSPlusSecretKey`...